### PR TITLE
BE-4-Add-Config-File

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -64,6 +64,20 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Apache Commons Configuration 2 for reading the configuration file-->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>2.3</version>
+        </dependency>
+
+        <!-- Apache Commons Beanutils needed by Apache Commons Configuration 2 -->
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.3</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/api/src/main/java/com/starbucks/api/PingResourceApi.java
+++ b/api/src/main/java/com/starbucks/api/PingResourceApi.java
@@ -1,5 +1,8 @@
 package com.starbucks.api;
 
+import com.starbucks.config.SharedConfig;
+
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -8,10 +11,17 @@ import javax.ws.rs.core.MediaType;
 @Path("v1")
 public class PingResourceApi {
 
+    private SharedConfig config;
+
+    @Inject
+    public PingResourceApi(SharedConfig config) {
+        this.config=config;
+    }
+
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/ping")
     public String ping() {
-        return "Pong!";
+        return "Pong!" +" from "+config.getString("appName");
     }
 }

--- a/api/src/main/java/com/starbucks/config/ConfigReader.java
+++ b/api/src/main/java/com/starbucks/config/ConfigReader.java
@@ -1,0 +1,51 @@
+package com.starbucks.config;
+
+import com.google.inject.Inject;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.FileBasedConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+
+import java.io.File;
+
+public class ConfigReader {
+    public static final String FILE_NAME="config.properties";
+    public static final String FILE_LOCATION="/src/main/resources";
+    public static final String FILE_PATH_APPENDER="/";
+    public Configuration config;
+
+    @Inject
+    public ConfigReader(){
+        this.config = init();
+    }
+
+    public Configuration init(){
+        Parameters params = new Parameters();
+        File propertiesFile = new File(getAbsoluteFileLocation());
+
+        FileBasedConfigurationBuilder<FileBasedConfiguration> builder =
+                new FileBasedConfigurationBuilder<FileBasedConfiguration>(PropertiesConfiguration.class)
+                        .configure(params.fileBased()
+                                .setFile(propertiesFile));
+        try {
+            Configuration config = builder.getConfiguration();
+            return config;
+        }
+        catch(ConfigurationException ex) {
+            ex.printStackTrace();
+            return null;
+        }
+    }
+
+
+    public String getAbsoluteFileLocation(){
+        return new StringBuilder()
+                .append(FILE_LOCATION)
+                .append(FILE_PATH_APPENDER)
+                .append(FILE_NAME)
+                .toString();
+    }
+
+}

--- a/api/src/main/java/com/starbucks/config/SharedConfig.java
+++ b/api/src/main/java/com/starbucks/config/SharedConfig.java
@@ -1,0 +1,24 @@
+package com.starbucks.config;
+
+public interface SharedConfig {
+
+    String getString(String key);
+
+    String getStringWithDefault(String key, String defaultValue);
+
+    Integer getInteger(String key);
+
+    Integer getIntegerWithDefault(String key, Integer defaultValue);
+
+    Boolean getBoolean(String key);
+
+    Boolean getBooleanWithDefault(String key, Boolean defaultValue);
+
+    Float getFloat(String key);
+
+    Float getFloatWithDefault(String key, Float defaultValue);
+
+    Double getDouble(String key);
+
+    Double getDoubleWithDefault(String key, Double defaultValue);
+}

--- a/api/src/main/java/com/starbucks/config/SharedConfigImpl.java
+++ b/api/src/main/java/com/starbucks/config/SharedConfigImpl.java
@@ -1,0 +1,64 @@
+package com.starbucks.config;
+
+import com.google.inject.Inject;
+
+public class SharedConfigImpl implements SharedConfig {
+
+    private ConfigReader configReader;
+
+    @Inject
+    public SharedConfigImpl(ConfigReader configReader) {
+        this.configReader = configReader;
+    }
+
+    @Override
+    public String getString(String key) {
+        return configReader.config.getString(key);
+    }
+
+    @Override
+    public String getStringWithDefault(String key, String defaultValue) {
+        return configReader.config.getString(key,defaultValue);
+    }
+
+    @Override
+    public Integer getInteger(String key) {
+        return configReader.config.getInt(key);
+    }
+
+    @Override
+    public Integer getIntegerWithDefault(String key, Integer defaultValue) {
+        return configReader.config.getInt(key, defaultValue);
+    }
+
+    @Override
+    public Boolean getBoolean(String key) {
+        Boolean val =  configReader.config.getBoolean(key);
+        return val;
+    }
+
+    @Override
+    public Boolean getBooleanWithDefault(String key, Boolean defaultValue) {
+        return configReader.config.getBoolean(key);
+    }
+
+    @Override
+    public Float getFloat(String key) {
+        return configReader.config.getFloat(key);
+    }
+
+    @Override
+    public Float getFloatWithDefault(String key, Float defaultValue) {
+        return configReader.config.getFloat(key,defaultValue);
+    }
+
+    @Override
+    public Double getDouble(String key) {
+        return configReader.config.getDouble(key);
+    }
+
+    @Override
+    public Double getDoubleWithDefault(String key, Double defaultValue) {
+        return configReader.config.getDouble(key,defaultValue);
+    }
+}

--- a/api/src/main/java/com/starbucks/guice/BaseModule.java
+++ b/api/src/main/java/com/starbucks/guice/BaseModule.java
@@ -5,6 +5,6 @@ import com.google.inject.AbstractModule;
 public class BaseModule extends AbstractModule {
     @Override
     protected void configure() {
-
+        install(new ConfigReaderModule());
     }
 }

--- a/api/src/main/java/com/starbucks/guice/ConfigReaderModule.java
+++ b/api/src/main/java/com/starbucks/guice/ConfigReaderModule.java
@@ -1,0 +1,14 @@
+package com.starbucks.guice;
+
+import com.google.inject.AbstractModule;
+import com.starbucks.config.ConfigReader;
+import com.starbucks.config.SharedConfig;
+import com.starbucks.config.SharedConfigImpl;
+
+public class ConfigReaderModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(ConfigReader.class);
+        bind(SharedConfig.class).to(SharedConfigImpl.class);
+    }
+}

--- a/api/src/main/resources/config.properties
+++ b/api/src/main/resources/config.properties
@@ -1,0 +1,1 @@
+appName=starbucks


### PR DESCRIPTION
**WHAT**: Adding configuration reading support for Apache Commons Configuration.

**WHY**: Apache Commons Configuration provides out of the box support for reading configurations.